### PR TITLE
fix: correct theme copy command and update GRUB configuration handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,14 +18,16 @@ fi
 
 # Copy theme
 if [ ! -d "$THEME_DIR/$THEME_NAME" ]; then
-    sudo cp -r $THEME_NAME/$THEME_DIR
+    sudo cp -r $THEME_NAME/ $THEME_DIR
 fi
 
 # Modify GRUB
 if grep -q "GRUB_THEME=" "$GRUB_CFG"; then
     sed -i "s|^GRUB_THEME=.*|GRUB_THEME=\"${THEME_DIR}/${THEME_NAME}/theme.txt\"|" "$GRUB_CFG"
 else
-    echo "GRUB_THEME=\"${THEME_DIR}/${THEME_NAME}/theme.txt\"" >> "$GRUB_CFG"
+    # Added extra line before the GRUB_THEME line
+    echo "" >> "$GRUB_CFG"
+    echo "GRUB_THEME=\"${THEME_DIR}/${THEME_NAME}/theme.txt\"" >>"$GRUB_CFG"
 fi
 
 # Updating GRUB


### PR DESCRIPTION
1. The `cp` command cannot work properly on line 21, this commit fixes this problem.
2. When the file `/etc/default/grub` is not ended with an empty line, the value GRUB_CFG cannot be read by `grub-mkconfig` after the modification of the script, so that GRUB menu won't change in the next boot. This commit adds an empty line using `echo` to fix this.